### PR TITLE
chore: update additional for rhel9 support

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -26,7 +26,7 @@
         db_locale: C.UTF-8
       when:
         - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '8'
+        - ansible_distribution_major_version >= '8'
         - lookup('env', 'CI') != 'true'
 
     - name: Install crontabs

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -14,6 +14,15 @@
   when:
     - ansible_distribution == 'Fedora'
 
+- name: install.redhat | install packages missing on RHEL9
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - cronie
+  when:
+    - ansible_distribution_major_version == '9'
+
 - name: install.redhat | install required system packages
   ansible.builtin.yum:
     name: "{{ item }}"


### PR DESCRIPTION
Update Ansible for RHEL9 support.

`crontab` functions appear to be a part of the `cronie` package in RHEL9.